### PR TITLE
Changes and fixes for 1 5

### DIFF
--- a/BackupScript.ps1
+++ b/BackupScript.ps1
@@ -84,14 +84,17 @@ $EmailSMTP = 'smtp.domain.com' #smtp server adress, DNS hostname.
 #Settings - do not change anything from here
 
 $ExcludeString=""
-#[string[]]$excludedArray = $ExcludeDirs -split "," 
 foreach ($Entry in $ExcludeDirs)
 {
-    $Temp="^"+$Entry.Replace("\","\\")
+    #Exclude the directory itself
+    $Temp="^"+$Entry.Replace("\","\\")+"$"
+    $ExcludeString+=$Temp+"|"
+
+    #Exclude the directory's children
+    $Temp="^"+$Entry.Replace("\","\\")+"\\.*"
     $ExcludeString+=$Temp+"|"
 }
 $ExcludeString=$ExcludeString.Substring(0,$ExcludeString.Length-1)
-#$ExcludeString
 [RegEx]$exclude = $ExcludeString
 
 if ($UseStaging -and $Zip)

--- a/BackupScript.ps1
+++ b/BackupScript.ps1
@@ -234,10 +234,7 @@ Function Make-Backup {
     }
 }
 
-
 #create Backup Dir
-
-
 
 Create-Backupdir
 Logging "INFO" "----------------------"
@@ -273,10 +270,9 @@ if ($CheckDir -eq $false) {
 
     $Enddate=Get-Date #-format dd.MM.yyyy-HH:mm:ss
     $span = $EndDate - $StartDate
-    $Minutes=$span.Minutes
-    $Seconds=$Span.Seconds
+    $Duration = $("Backup duration " + $span.Hours.ToString() + " hours " + $span.Minutes.ToString() + " minutes " + $span.Seconds.ToString() + " seconds")
 
-    Logging "INFO" "Backupduration $Minutes Minutes and $Seconds Seconds"
+    Logging "INFO" $Duration
     Logging "INFO" "----------------------"
     Logging "INFO" "----------------------" 
 
@@ -319,14 +315,9 @@ if ($CheckDir -eq $false) {
 
         }
 
-
-
-
-
-
         If ($RemoveBackupDestination)
         {
-            Logging "INFO" "Backupduration $Minutes Minutes and $Seconds Seconds"
+            Logging "INFO" $Duration
 
             #Remove-Item -Path $BackupDir -Force -Recurse 
             get-childitem -Path $BackupDir -recurse -Force  | remove-item -Confirm:$false -Recurse
@@ -338,6 +329,3 @@ if ($CheckDir -eq $false) {
 Write-Host "Press any key to close ..."
 
 $x = $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
-
-
-

--- a/BackupScript.ps1
+++ b/BackupScript.ps1
@@ -196,7 +196,7 @@ Function Make-Backup {
         # Use -LiteralPath option to work around known issue with PowerShell FileSystemProvider wildcards.
         # See: https://github.com/PowerShell/PowerShell/issues/6733
 
-        $Files = Get-ChildItem -LiteralPath $Backup -recurse -Force -Directory -ErrorVariable +errItems -ErrorAction SilentlyContinue | 
+        $Files = Get-ChildItem -LiteralPath $Backup -recurse -Attributes D+!ReparsePoint,D+H+!ReparsePoint -ErrorVariable +errItems -ErrorAction SilentlyContinue | 
             ForEach-Object -Process {Add-Member -InputObject $_ -NotePropertyName "ParentFullName" -NotePropertyValue ($_.FullName.Substring(0, $_.FullName.LastIndexOf("\"+$_.Name))) -PassThru -ErrorAction SilentlyContinue} |
             Where-Object {$_.FullName -notmatch $exclude -and $_.ParentFullName -notmatch $exclude} |
             Get-ChildItem -Attributes !D -ErrorVariable +errItems -ErrorAction SilentlyContinue | Where-Object {$_.DirectoryName -notmatch $exclude}


### PR DESCRIPTION
This PR includes 4 commits. I have comments in each, but will summarize here.

Fixed Backup Duration log message.
Previously it was only displaying the Minutes & Seconds properties which are components of the time, not the total time. So, the duration was 1:07:45 it would only appear to have taken 0:07:45...
"Backupduration 7 Minutes and 45 Seconds"
It will now display:
"Backup duration 1 hours 7 minutes 45 seconds"

Fixed issue where sibling folders of an excluded folder starting with the same name were also excluded.
If $ExcludeDirs contained "C:\Test\Exclude_Me", if there was a sibling folder that started with the same name such as "C:\Test\Exclude_Me_NOT", it would also be excluded.

Improve performance by refactoring to only recurse folders and files once and storing in hash table.

Updated to use -LiteralPath option to work around known issue with PowerShell FileSystemProvider wildcards. See:
https://github.com/PowerShell/PowerShell/issues/6733

Updated to include hidden folders & files.
Needed to include $env:USERPROFILE\AppData because the "Roaming" subfolder contains data that is desirable (ex. FireFox user profiles).
Considered work around of manually including these, but if backing up multiple users, the destination would merge them all into the same folder.

Added default $ExcludeDirs:
($env:SystemDrive + "\Users\.*\AppData\Local")
($env:SystemDrive + "\Users\.*\AppData\LocalLow")
Only the sibling Roaming folder contains user data.

Note: Calling New-Item to create destination directory is required as $Files now only contains files (it no longer includes folders). I believe that overall performance is still better. It could be reconsidered in future refactorings.

Fixed issue (I had created in prior commit) where Symbolic Links (ReparsePoints) would be iterated and logged as skipped errors in the log. Updated the recursion of directories to only include Directories and Hidden Directories (excluding ReparsePoints).